### PR TITLE
Small changes, to work with Adafruit BNO055 lib ^1.6.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,12 +8,14 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:teensy31]
+[env:teensylc]
 platform = teensy
 framework = arduino
-board = teensy31
+board = teensylc
 build_flags = -D USB_MIDI_SERIAL
-lib_deps = adafruit/Adafruit BNO055@^1.4.3
+lib_deps =
+  SPI
+  adafruit/Adafruit BNO055@^1.6.0
 
 ; [env:teensy30]
 ; platform = teensy

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,7 +156,7 @@ void setup() {
       ;
   }
 
-  if (!bno.begin(bno.OPERATION_MODE_IMUPLUS)) {
+  if (!bno.begin(OPERATION_MODE_IMUPLUS)) {
     /* There was a problem detecting the BNO055 ... check your connections */
     Serial.print(
         "Ooops, no BNO055 detected ... Check your wiring or I2C ADDR!");


### PR DESCRIPTION
Platformio downloads the latest version of the Adafruit BNO055 lib (currently v1.6.1).
There's a small change in that version which gives an error in this version of the TeensyHeadTracker.

Since the README mentions a Teensy LC, I've also changed the .ini file for this. 

I haven't tested the hardware yet, but now the code compiles. 